### PR TITLE
Now only uses beastballs on beast pokemons

### DIFF
--- a/src/scripts/pokeballs/Pokeballs.ts
+++ b/src/scripts/pokeballs/Pokeballs.ts
@@ -176,7 +176,7 @@ class Pokeballs implements Feature {
                 return GameConstants.Pokeball.None;
             }
         } else if (GameConstants.UltraBeastType[pokemon.name] != undefined) {
-            if (this.pokeballs[GameConstants.Pokeball.Beastball].quantity() > 0) {
+            if (pref != GameConstants.Pokeball.None && this.pokeballs[GameConstants.Pokeball.Beastball].quantity() > 0) {
                 return GameConstants.Pokeball.Beastball;
             } else {
                 return GameConstants.Pokeball.None;

--- a/src/scripts/pokeballs/Pokeballs.ts
+++ b/src/scripts/pokeballs/Pokeballs.ts
@@ -169,7 +169,6 @@ class Pokeballs implements Feature {
 
         let use: GameConstants.Pokeball = GameConstants.Pokeball.None;
 
-        console.log(pref);
         if (pref == GameConstants.Pokeball.Beastball) {
             if (GameConstants.UltraBeastType[pokemon.name] != undefined && this.pokeballs[GameConstants.Pokeball.Beastball].quantity() > 0) {
                 return GameConstants.Pokeball.Beastball;

--- a/src/scripts/pokeballs/Pokeballs.ts
+++ b/src/scripts/pokeballs/Pokeballs.ts
@@ -146,6 +146,7 @@ class Pokeballs implements Feature {
     public calculatePokeballToUse(id: number, isShiny: boolean): GameConstants.Pokeball {
         const alreadyCaught = App.game.party.alreadyCaughtPokemon(id);
         const alreadyCaughtShiny = App.game.party.alreadyCaughtPokemon(id, true);
+        const pokemon = PokemonHelper.getPokemonById(id);
         let pref: GameConstants.Pokeball;
 
         // just check against alreadyCaughtShiny as this returns false when you don't have the pokemon yet.
@@ -168,12 +169,18 @@ class Pokeballs implements Feature {
 
         let use: GameConstants.Pokeball = GameConstants.Pokeball.None;
 
-        // Workaround for UB quest, a better solution would be good
-        if (typeof GameConstants.UltraBeastType[Battle.enemyPokemon().name] === 'number') {
-            if (this.pokeballs[GameConstants.Pokeball.Beastball].quantity() > 0) {
-                pref = GameConstants.Pokeball.Beastball;
+        console.log(pref);
+        if (pref == GameConstants.Pokeball.Beastball) {
+            if (GameConstants.UltraBeastType[pokemon.name] != undefined && this.pokeballs[GameConstants.Pokeball.Beastball].quantity() > 0) {
+                return GameConstants.Pokeball.Beastball;
             } else {
-                pref = GameConstants.Pokeball.None;
+                return GameConstants.Pokeball.None;
+            }
+        } else if (GameConstants.UltraBeastType[pokemon.name] != undefined) {
+            if (this.pokeballs[GameConstants.Pokeball.Beastball].quantity() > 0) {
+                return GameConstants.Pokeball.Beastball;
+            } else {
+                return GameConstants.Pokeball.None;
             }
         }
 


### PR DESCRIPTION
The logic behind the new way of using beastballs:
- if beastballs are selected, for the category, only beasts will be attempted to be catched
- if other balls are selected, beastballs will be used on beasts
- if no catch is selected, none will be attempted to be caught