### PR TITLE
Fixed catchrate being 0% for non-beasts

### DIFF
--- a/src/scripts/Battle.ts
+++ b/src/scripts/Battle.ts
@@ -131,13 +131,7 @@ class Battle {
     protected static prepareCatch(enemyPokemon: BattlePokemon, pokeBall: GameConstants.Pokeball) {
         this.pokeball(pokeBall);
         this.catching(true);
-        if (typeof GameConstants.UltraBeastType[enemyPokemon.name] == 'number') {
-            if (pokeBall == GameConstants.Pokeball.Beastball) { // TODO: Make this work for Masterballs?
-                this.catchRateActual(this.calculateActualCatchRate(enemyPokemon, pokeBall));
-            } else {
-                this.catchRateActual(0);
-            }
-        }
+        this.catchRateActual(this.calculateActualCatchRate(enemyPokemon, pokeBall));
         App.game.pokeballs.usePokeball(pokeBall);
     }
 


### PR DESCRIPTION
The bug was there, because this.catchRateActual() was never called for, if the pokemon was not a beast.
I have removed this code entirely, now that beastballs only can be used on beasts, and normal balls never can be used on beast. It will just never come up